### PR TITLE
fix: pod name with invalid character

### DIFF
--- a/react-native-photos-framework.podspec
+++ b/react-native-photos-framework.podspec
@@ -2,7 +2,7 @@ require 'json'
 pkg = JSON.parse(File.read("package.json"))
 
 Pod::Spec.new do |s|
-  s.name         = pkg["name"]
+  s.name         = "react-native-photos-framework"
   s.version      = pkg["version"]
   s.summary      = pkg["description"]
   s.requires_arc = true


### PR DESCRIPTION
`pkg["name"]` resolves to a scoped package name: `@vforvasile/react-native-photos-framework`, which is not valid pod name AFAIK. Changing it to the same name as the podspec file is named, which is an established practice.